### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/github-script@v6
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # v6
         env:
           VERSION: ${{ inputs.version }}
         with:

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -16,7 +16,7 @@ jobs:
   self-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: ./
         name: Render multiple files and check for changes
         with:


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `.github/` workflow files to full-length commit SHAs

Generated by `devenv pin_gha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)